### PR TITLE
Edits To OpenShift Pipelines Workshop

### DIFF
--- a/workshop/content/concepts.adoc
+++ b/workshop/content/concepts.adoc
@@ -1,21 +1,20 @@
 Tekton defines a number of link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[Kubernetes custom resources] as building blocks in order to standardize pipeline concepts and provide a terminology that is consistent across CI/CD solutions. These custom resources (CR) are an extension of Kubernetes that let users create and interact with these objects using `kubectl` and other Kubernetes tools.
 
-The custom resources needed to define a pipeline are:
-
-* `Task`: a reusable loosely-coupled number of steps that perform a specific task e.g building a container image
-* `Pipeline`: the definition of the pipeline and the `Tasks` that it should perform
-* `PipelineResource`: inputs (e.g. git repository) and outputs (image registry) to and out of a pipeline or task
-* `TaskRun`: the result of running an instance of task
-* `PipelineRun`: the result of running an instance of pipeline, which includes a number of `TaskRuns`
+The custom resources needed to define a `pipeline` are:
+* `Task`: a reusable, loosely coupled number of steps that perform a specific `task` (e.g., building a container image)
+* `Pipeline`: the definition of the `pipeline` and the `tasks` that it should perform
+* `PipelineResource`: inputs (e.g., git repository) and outputs (e.g., image registry) to and out of a `pipeline` or `task`
+* `TaskRun`: the result of running an instance of `task`
+* `PipelineRun`: the result of running an instance of `pipeline`, which includes a number of `taskruns`
 
 image:images/tekton-architecture.svg[Tekton Architecture]
 
-In short, in order to create a pipeline, one does the following:
+In short, in order to create a `pipeline`, one does the following:
 
-* Create custom or install link:https://github.com/tektoncd/catalog[existing] reusable `Tasks`
-* Create a `Pipeline` and `PipelneResources` to define your application's delivery pipeline
-* Create a `PipelineRun` to instantiate and invoke the pipeline
+* Create custom or install link:https://github.com/tektoncd/catalog[existing] reusable `tasks`
+* Create a `pipeline` and `pipelneresources` to define your application's delivery `pipeline`
+* Create a `pipelineRun` to instantiate and invoke the `pipeline`
 
-For further details on pipeline concepts, refer to the link:https://github.com/tektoncd/pipeline/tree/master/docs#learn-more[Tekton documentation] that provides an excellent guide for understanding various parameters and attributes available for defining pipelines.
+For further details on pipeline concepts, refer to the link:https://github.com/tektoncd/pipeline/tree/master/docs#learn-more[Tekton documentation] that provides an excellent guide for understanding various parameters and attributes available for defining `pipelines`.
 
-In the following sections, you will go through each of the above steps to define and invoke a pipeline.
+In the following sections, you will go through each of the above steps to define and invoke a `pipeline`.

--- a/workshop/content/concepts.adoc
+++ b/workshop/content/concepts.adoc
@@ -3,17 +3,17 @@ Tekton defines a number of link:https://kubernetes.io/docs/concepts/extend-kuber
 The custom resources needed to define a pipeline are:
 
 * `Task`: a reusable loosely-coupled number of steps that perform a specific task e.g building a container image
-* `Pipeline`: the definition of the pipeline and the `Task`s that it should perform
+* `Pipeline`: the definition of the pipeline and the `Tasks` that it should perform
 * `PipelineResource`: inputs (e.g. git repository) and outputs (image registry) to and out of a pipeline or task
 * `TaskRun`: the result of running an instance of task
-* `PipelineRun`: the result of running an instance of pipeline, which includes a number of `TaskRun`s
+* `PipelineRun`: the result of running an instance of pipeline, which includes a number of `TaskRuns`
 
 image:images/tekton-architecture.svg[Tekton Architecture]
 
 In short, in order to create a pipeline, one does the following:
 
 * Create custom or install link:https://github.com/tektoncd/catalog[existing] reusable `Tasks`
-* Create a `Pipeline` and `PipelneResource`s to define your application's delivery pipeline
+* Create a `Pipeline` and `PipelneResources` to define your application's delivery pipeline
 * Create a `PipelineRun` to instantiate and invoke the pipeline
 
 For further details on pipeline concepts, refer to the link:https://github.com/tektoncd/pipeline/tree/master/docs#learn-more[Tekton documentation] that provides an excellent guide for understanding various parameters and attributes available for defining pipelines.

--- a/workshop/content/concepts.adoc
+++ b/workshop/content/concepts.adoc
@@ -1,6 +1,7 @@
 Tekton defines a number of link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[Kubernetes custom resources] as building blocks in order to standardize pipeline concepts and provide a terminology that is consistent across CI/CD solutions. These custom resources (CR) are an extension of Kubernetes that let users create and interact with these objects using `kubectl` and other Kubernetes tools.
 
 The custom resources needed to define a `pipeline` are:
+
 * `Task`: a reusable, loosely coupled number of steps that perform a specific `task` (e.g., building a container image)
 * `Pipeline`: the definition of the `pipeline` and the `tasks` that it should perform
 * `PipelineResource`: inputs (e.g., git repository) and outputs (e.g., image registry) to and out of a `pipeline` or `task`

--- a/workshop/content/exercises/create-pipeline.adoc
+++ b/workshop/content/exercises/create-pipeline.adoc
@@ -57,11 +57,11 @@ To create the `pipeline` above, you will have the option of using the OpenShift 
 
 = OpenShift CLI
 
-The command below uses `oc` to take the `pipeline` definition from above from a GitHub repository and then creates it in your OpenShift project. Run the command to create the `pipeline`:
+The command below uses `oc` to take the `pipeline` definition from above from a local directory and then creates it in your OpenShift project. Run the command to create the `pipeline`:
 
 [source,bash,role=execute-1]
 ----
-oc create -f https://raw.githubusercontent.com/openshift-labs/lab-openshift-pipelines-with-tekton/master/code/exercise/deploy-pipeline.yaml
+oc create -f ./code/exercise/deploy-pipeline.yaml
 ----
 
 = OpenShift Web Console
@@ -72,7 +72,7 @@ image:../images/console-import-yaml-1.png[OpenShift Console - Import Yaml Menu]
 
 image:../images/console-import-yaml-2.png[OpenShift Console - Import Yaml]
 
-You can check the list of `pipelines` you have created using the Tekton CLI:
+You can check the list of `pipelines` you have created using the [Tekton CLI](https://github.com/tektoncd/cli/releases)(`tkn`):
 
 [source,bash,role=execute-1]
 ----

--- a/workshop/content/exercises/create-pipeline.adoc
+++ b/workshop/content/exercises/create-pipeline.adoc
@@ -57,12 +57,12 @@ To create the `pipeline` above, you will have the option of using the OpenShift 
 
 = OpenShift CLI
 
+The command below uses `oc` to take the `pipeline` definition from above from a GitHub repository and then creates it in your OpenShift project. Run the command to create the `pipeline`:
+
 [source,bash,role=execute-1]
 ----
 oc create -f https://raw.githubusercontent.com/openshift-labs/lab-openshift-pipelines-with-tekton/master/code/exercise/deploy-pipeline.yaml
 ----
-
-The command above uses `oc` to take the `pipeline` definition from above from a GitHub repository and then creates it in your OpenShift project.
 
 = OpenShift Web Console
 

--- a/workshop/content/exercises/create-pipeline.adoc
+++ b/workshop/content/exercises/create-pipeline.adoc
@@ -1,10 +1,10 @@
-A pipeline defines a number of tasks that should be executed and how they interact with each other via their inputs and outputs.
+A `pipeline` defines a number of `tasks` that should be executed and how they interact with each other via their inputs and outputs.
 
-In this tutorial, you will create a pipeline that takes the source code of PetClinic application from GitHub and then builds and deploys it on OpenShift using link:https://docs.openshift.com/container-platform/4.1/builds/understanding-image-builds.html#build-strategy-s2i_understanding-image-builds[Source-to-Image (S2I)].
+In this tutorial, you will create a `pipeline` that takes the source code of a Java Spring Boot application (i.e., Spring PetClinic) from GitHub and then builds and deploys it on OpenShift using link:https://docs.openshift.com/container-platform/4.1/builds/understanding-image-builds.html#build-strategy-s2i_understanding-image-builds[Source-to-Image (S2I)].
 
 image:../images/pipeline-diagram.svg[OpenShift OperatorHub]
 
-Here is the YAML file that represents the above pipeline:
+Below is a YAML file that represents the above pipeline:
 
 [source,yaml]
 ----
@@ -42,29 +42,41 @@ spec:
       value: "rollout latest spring-petclinic"
 ----
 
-This pipeline performs the following:
+This `pipeline` performs the following:
 
-1. Clones the source code of the application from a Git repository (`app-git` resource)
-3. Builds the container image using the `s2i-java-8` task that generates a Dockerfile for the application and uses link:https://buildah.io/[Buildah] to build the image
-4. The application image is pushed to an image registry (`app-image` resource)
+1. Clones the source code of the application from a Git repository (i.e., `app-git` resource)
+3. Builds the container image using the `s2i-java-8` `task` that generates a Dockerfile for the application and uses link:https://buildah.io/[Buildah] to build the image
+4. The application image is pushed to an image registry (i.e., `app-image` resource)
 5. The new application image is deployed on OpenShift using the `openshift-cli`
 
-You might have noticed that there are no references to the PetClinic Git repository and its image in the registry. That's because `Pipeline`s in Tekton are designed to be generic and re-usable across environments and stages through the application's lifecycle. `Pipeline`s abstract away the specifics of the Git source repository and image to be produced as `resource`s. When triggering a pipeline, you can provide different Git repositories and image registries to be used during pipeline execution. Be patient! You will do that in a little bit in the next section.
+You might have noticed that there are no references to the PetClinic Git repository and its image in the registry. That's because `Pipelines` in Tekton are designed to be generic and reusable across environments and stages through the application's lifecycle. `Pipelines` abstract away the specifics of the Git source repository and image to be produced as `pipelineresources`. When triggering a `pipeline`, you can provide different Git repositories and image registries to be used during a `pipeline` execution. You will do that in a little bit in the next section.
 
-The tasks execution order is determined based on the dependencies that are defined between the tasks via `inputs` and `outputs` as well as explicit orders that are defined via `runAfter`.
+The `tasks` execution order is determined based on the dependencies that are defined between the `tasks` via `inputs` and `outputs` as well as explicit orders that are defined via `runAfter`. You'll notice the `deploy` task above has a `runAfter` specifying to only execute after the `build` task is complete.
 
-Save the pipeline definition as a `.yaml` file and then create it using `oc create -f YOUR_FILE_NAME.yaml`. Alternatively, in the OpenShift console, you can click on **Add &#8594; Import YAML** at the top right of the screen while you are in the **pipelines-tutorial** project, paste the YAML into the textfield, and click on **Create**.
+To create the `pipeline` above, you will have the option of using the OpenShift CLI (`oc`) or using the OpenShift Web Console:
+
+= OpenShift CLI
+
+[source,bash,role=execute-1]
+----
+oc create -f https://raw.githubusercontent.com/openshift-labs/lab-openshift-pipelines-with-tekton/master/code/exercise/deploy-pipeline.yaml
+----
+
+The command above uses `oc` to take the `pipeline` definition from above from a GitHub repository and then creates it in your OpenShift project.
+
+= OpenShift Web Console
+
+Alternatively, in the OpenShift web console, you can click on **Add &#8594; Import YAML** at the top right of the screen while you are in the **pipelines-tutorial** project, paste the YAML into the textfield, and click on **Create**.
 
 image:../images/console-import-yaml-1.png[OpenShift Console - Import Yaml Menu]
 
 image:../images/console-import-yaml-2.png[OpenShift Console - Import Yaml]
 
+You can check the list of `pipelines` you have created using the Tekton CLI:
 
-Check the list of pipelines you have created using the CLI:
-
-[source,bash]
+[source,bash,role=execute-1]
 ----
 $ tkn pipeline ls
 NAME             AGE              LAST RUN   STARTED   DURATION   STATUS
-build-pipeline   25 seconds ago   ---        ---       ---        ---
+deploy-pipeline  25 seconds ago   ---        ---       ---        ---
 ----

--- a/workshop/content/exercises/deploy-sample-app.adoc
+++ b/workshop/content/exercises/deploy-sample-app.adoc
@@ -1,29 +1,33 @@
-For this tutorial we're going to use a simple sample application. The workshop is configured to provide you a pre-created project. We can verify the name of the project with:
+For this tutorial we're going to use a simple Java application. The workshop is configured to provide you a pre-created project. We can verify the name of the project with:
 
 [source,bash,role=execute-1]
 ----
 oc project -q
 ----
 
-Building container images using build tools such as `S2I`, `Buildah`, `Kaniko`, etc require privileged access to the cluster. OpenShift default security setting does not allow privileged containers unless specifically configured. 
+Building container images using build tools such as `S2I`, `Buildah`, `Kaniko`, etc require privileged access to the cluster. OpenShift default security setting does not allow privileged containers unless specifically configured.
 
-This workshop has created a ServiceAccount with the required permissions to run privileged pods for building images. The name of this service Account is easy to remember, `pipeline`:
+This workshop has created a ServiceAccount with the required permissions to run privileged pods for building images. The name of this service account is easy to remember. It is named `pipeline`. You can view information about `pipeline` by running the command below:
 
 [source,bash,role=execute-1]
 ----
 oc get serviceaccount pipeline
 ----
 
-Now, let's verify that has the appropriate permission, access to the `privileged` Security Context Constrain (SCC):
+Now, let's verify that `pipeline` has the appropriate permissions to access the `privileged` Security Context Constrain (SCC):
 
 [source,bash,role=execute-1]
 ----
 oc auth can-i use scc/privileged
 ----
 
+= TODO: Add output to verify service account has appropriate permissions
+
+Now that we have verified the `pipeline` account has appropriate permissions, let's focus on the application that will be deployed during this workshop.
+
 You will use the link:https://github.com/spring-projects/spring-petclinic[Spring PetClinic] sample application during this tutorial, which is a simple Spring Boot application.
 
-Create the Kubernetes objects for deploying the PetClinic app on OpenShift. The deployment will not complete since there are no container images built for the PetClinic application yet. That you will do in the following sections through a CI/CD pipeline:
+Create the Kubernetes objects for deploying the PetClinic app on OpenShift by running the command below. The deployment will not complete since there are no container images built for the PetClinic application yet. That you will do in the following sections through a CI/CD pipeline.
 
 [source,bash,role=execute-1]
 ----

--- a/workshop/content/exercises/install-tasks.adoc
+++ b/workshop/content/exercises/install-tasks.adoc
@@ -1,4 +1,4 @@
-**Task**'s consist of a number of steps that are executed sequentially. Each **task** is executed in a separate container within the same pod. They can also have inputs and outputs in order to interact with other tasks in the pipeline.
+`Tasks` consist of a number of steps that are executed sequentially. Each `task` is executed in a separate container within the same pod. They can also have inputs and outputs in order to interact with other `tasks` in the `pipeline`.
 
 Here is an example of a Maven task for building a Maven-based Java application:
 
@@ -23,21 +23,21 @@ spec:
     - install
 ----
 
-When a **task** starts running, it starts a pod and runs each **step** sequentially in a separate container on the same pod. This task happens to have a single step, but tasks can have multiple steps, and, since they run within the same pod, they have access to the same volumes in order to cache files, access configmaps, secrets, etc. `Task`s can also receive inputs (e.g. a git repository) and outputs (e.g. an image in a registry) in order to interact with each other.
+When a `task` starts running, it starts a pod and runs each step sequentially in a separate container on the same pod. This `task` happens to have a single step, but `tasks` can have multiple steps, and, since they run within the same pod, they have access to the same volumes in order to cache files, access configmaps, secrets, etc. `Tasks` can also receive inputs (e.g., a git repository) and outputs (e.g., an image in a registry) in order to interact with each other.
 
-Note that only the requirement for a git repository is declared on the task and not a specific git repository to be used. That allows `task`s to be reusable for multiple pipelines and purposes. You can find more examples of reusable `task`s in the link:https://github.com/tektoncd/catalog[Tekton Catalog] and link:https://github.com/openshift/pipelines-catalog[OpenShift Catalog] repositories.
+As mentioned previously, only the requirement for a git repository is declared on the `task` and not a specific git repository to be used. That allows `tasks` to be reusable for multiple `pipelines` and purposes. You can find more examples of reusable `tasks` in the link:https://github.com/tektoncd/catalog[Tekton Catalog] and link:https://github.com/openshift/pipelines-catalog[OpenShift Catalog] repositories.
 
-Install the `openshift-client` and `s2i-java` tasks from the catalog repository using `oc` or `kubectl`, which you will need for creating a pipeline in the next section:
+Install the `openshift-client` and `s2i-java` tasks from the catalog repository using `oc`, which you will need for creating a pipeline in the next section:
 
 [source,bash,role=execute-1]
 ----
-oc create -f tektontasks/openshift-client-task.yaml
-oc create -f tektontasks/s2i-java-8-task.yaml
+oc create -f ./code/tektontasks/openshift-client-task.yaml
+oc create -f ./code/tektontasks/s2i-java-8-task.yaml
 ----
 
-NOTE: For convenience, the tasks have been copied from it's original location in the link:https://github.com/tektoncd/catalog[Tekton Catalog] to the workshop.
+**NOTE**: For convenience, the `tasks` have been copied from their original location in the link:https://github.com/tektoncd/catalog[Tekton Catalog] to the workshop.
 
-You can take a look at the list of install `task`s using the [Tekton CLI](https://github.com/tektoncd/cli/releases) already installed on the workshop environment:
+You can take a look at the list of installed `tasks` using `tkn`:
 
 [source,bash,role=execute-1]
 ----

--- a/workshop/content/exercises/trigger-pipeline.adoc
+++ b/workshop/content/exercises/trigger-pipeline.adoc
@@ -1,8 +1,8 @@
-Now that the pipeline is created, you can trigger it to execute the tasks specified in the pipeline. Triggering pipelines is an area that is under development and in the next release it will be possible to be done via the OpenShift web console and Tekton CLI. In this tutorial, you will trigger the pipeline through creating the Kubernetes objects (the hard way!) in order to learn the mechanics of triggering.
+Now that the `pipeline` is created, you can trigger it to execute the tasks specified in the `pipeline`. Triggering `pipelines` is an area that is under development and in the next release it will be possible to be done via the OpenShift web console and Tekton CLI. In this tutorial, you will trigger the pipeline through creating the Kubernetes objects (the hard way!) in order to learn the mechanics of triggering.
 
-First, you should create a number of `PipelineResource`s that contain the specifics of the Git repository and image registry to be used in the pipeline during execution. Expectedly, these are also reusable across multiple pipelines.
+First, you should create `pipelineresources` that contain the specifics of the Git repository and image registry to be used in the `pipeline` during execution. Expectedly, these are also reusable across multiple pipelines.
 
-The following `PipelineResource` defines the Git repository and reference for the PetClinic application:
+The following `pipelineresource` defines the Git repository and reference for the PetClinic application:
 
 [source,yaml]
 ----
@@ -32,9 +32,15 @@ spec:
     value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/spring-petclinic
 ----
 
-Create the above pipeline resources via the OpenShift web console or save them in a file and use `oc create -f`.
+Create the above pipeline resources via the OpenShift web console using the same steps used earlier for creating the `pipeline` or execute the following `oc` commands:
 
-A `PipelineRun` is how you can trigger a pipeline and tie it to the Git and image resources that should be used for this specific invocation:
+[source,bash,role=execute-1]
+----
+oc create -f ./code/exercise/petclinic-git-pipeline-resource.yaml
+oc create -f ./code/exercise/petclinic-image-pipeline-resource.yaml
+----
+
+A `pipelinerun` is how you can trigger a `pipeline` and tie it to the Git and image resources that should be used for this specific invocation:
 
 [source,yaml]
 ----
@@ -57,20 +63,27 @@ spec:
       name: petclinic-image
 ----
 
-Create the above pipeline resources via the OpenShift web console or save them in a file and use `oc create -f`.
+Create the above `pipelinerun` via the OpenShift web console using the same steps used earlier for creating the `pipeline` or run the following `oc` command:
 
-The pipeline would then get instantiated and create a number of pods to execute the tasks that are defined in the pipeline. After a few minutes, the pipeline should finish successfully.
+[source,bash,role=execute-1]
+----
+oc create -f ./code/exercise/petclinic-deploy-pipelinerun.yaml
+----
 
-[source,bash]
+The `pipeline` you created earlier is now instantiated and creating a number of pods to execute the `tasks` that are defined in the `pipeline`. After a few minutes, the `pipeline` should finish successfully.
+
+[source,bash,role=execute-1]
 ----
 # tkn pr ls
 NAME                                 STARTED         DURATION    STATUS
 petclinic-deploy-pipelinerun-lkq7d   7 minutes ago   3 minutes   Succeeded
 ----
 
-Check the pipelinerun logs as it executes:
+= TODO: Show how to view pipelinerun through web console
 
-[source,bash]
+Check the `pipelinerun` logs as it executes:
+
+[source,bash,role=execute-1]
 ----
 $ tkn pr logs petclinic-deploy-pipelinerun-lkq7d -f
 ...

--- a/workshop/content/install-tekton-operator.adoc
+++ b/workshop/content/install-tekton-operator.adoc
@@ -1,18 +1,18 @@
 OpenShift Pipelines is provided as an add-on on top of OpenShift that can be installed via an operator that is available in the OpenShift OperatorHub.
 
-OpenShift Pipelines operator installs globally on the cluster and will then monitor and manage pipelines for every single user in the cluster.
+The OpenShift Pipelines operator installs globally on the cluster and will then monitor and manage `pipelines` for every single user in the cluster.
 
-To install the operator, you need to be a cluster administrator user. In this workshop environment, the Operator has already been installed for you. Nevertheless, this is the process we followed in order to install the Operator. This instructions are for reference, as you will not be able to see these screens in the embedded console in the workshop due to the lack of the required privileges.
+To install the operator, you need to be a cluster administrator user. In this workshop environment, the operator has already been installed for you. Nevertheless, this is the process we followed in order to install the operator. These instructions are for reference, as you will not be able to see these screens in the embedded console in the workshop due to your user's lack of the required privileges.
 
 == Install process
 
 Go to **Catalog > OperatorHub** in the web console. You can see the list of available operators for OpenShift provided by Red Hat as well as a community of partners and open-source projects.
 
-Click on **Integration & Delivery** category to find **OpenShift Pipeline Operator**.
+Click on the **Integration & Delivery** category to find the **OpenShift Pipeline Operator**.
 
 image:images/operatorhub.png[OpenShift OperatorHub]
 
-Click on **OpenShift Pipelines Operator**, **Continue**, and then **Install**
+Click on **OpenShift Pipelines Operator**, **Continue**, and then **Install**.
 
 TODO: Update image
 
@@ -24,7 +24,7 @@ TODO: Update image
 
 image:images/operator-install-2.png[OpenShift Pipelines Operator]
 
-The operator is installed when you see the status updated from `1 installing` to `1 installed`. This operator automates installation and updates of OpenShift Pipelines on the cluster and applies all configurations needed.
+The operator is installed when you see the status updated from `1 installing` to `1 installed`. This operator automates installation and updates of OpenShift Pipelines on the cluster as well as applying all configurations needed.
 
 TODO: Update image
 

--- a/workshop/content/verify-workshop-environment.adoc
+++ b/workshop/content/verify-workshop-environment.adoc
@@ -1,6 +1,6 @@
-The OpenShift Pipelines operator is installed in the platform to monitor requests to create Pipelines and related resources. The operator can only be deployed and setup by a cluster admin of the OpenShift cluster, as we have previously discussed.
+The OpenShift Pipelines operator is installed in the platform to monitor requests to create `pipelines` and related resources. The operator can only be deployed and setup by a cluster admin of the OpenShift cluster, as we have previously discussed.
 
-The OpenShift Pipelines operator has been pre-installed in the cluster and is ready for use during this workshop. Your user has been granted the appropriate permissions to create Pipelines, Tasks, PipelineRuns and TaskRuns amongst other.
+The OpenShift Pipelines operator has been pre-installed in the cluster and is ready for use during this workshop. Your user has been granted the appropriate permissions to create `pipelines`, `tasks`, `pipelineruns`, and `taskruns` for this workshop.
 
 The OpenShift Pipelines operator provides all it's resources under a single api group `tekton.dev`. To see all the resources provided by the operator:
 
@@ -11,7 +11,7 @@ oc api-resources --api-group=tekton.dev
 
 To validate that your user has been granted the appropriate roles, you can use the `oc auth can-i` command to see whether you can create Kubernetes Custom Resources (CR) of the kind the OpenShift Pipelines operator responds to.
 
-The CR you need to create to declare a OpenShift Pipelines Pipeline is a Resource of the kind `pipeline` in the `tekton.dev` api group. To check that you can create this, run:
+The CR you need to create to declare an OpenShift Pipelines `pipeline` is a resource of the kind `pipeline` in the `tekton.dev` api group. To check that you can create this, run:
 
 [source,bash,role=execute]
 ----
@@ -27,7 +27,7 @@ oc auth can-i create Pipeline
 
 Did you type the command in yourself? If you did, click on the command here instead and you will find that it is executed for you. You can click on any command here in the workshop notes which has the image:images/glyphicon-play-circle.png[Play,16,16] icon shown to the right of it, and it will be copied to the interactive terminal and run for you.
 
-When run, if the response is `yes` you have the appropriate access.
+When run, if the response is `yes`, you have the appropriate access.
 
 TODO: Is there a way to verify the installation of the operator in the cluster?
 
@@ -37,14 +37,14 @@ We also need to verify that the OpenShift Pipelines operator has been enabled in
 
 [source,bash,role=execute]
 ----
-# oc rollout status deployment/openshift-pipelines-operator -n openshift-operators
----
+# oc rollout status deployment/openshift-pipelines-operator -n openshift-operators
+----
 
 You should see a message:
 
 [source,bash]
 ----
-# deployment "openshift-pipelines-operator" successfully rolled out
+deployment "openshift-pipelines-operator" successfully rolled out
 ----
 
 Now that we have verified that the operator is properly installed and that you can create the required resources, let's start the workshop.

--- a/workshop/content/workshop-overview.adoc
+++ b/workshop/content/workshop-overview.adoc
@@ -1,4 +1,4 @@
-OpenShift Pipelines is a cloud-native, continuous integration and delivery (CI/CD) solution for building pipelines using link:https://tekton.dev[Tekton]. Tekton is a flexible, Kubernetes-native, open-source CI/CD framework that enables automating deployments across multiple platforms (Kubernetes, serverless, VMs, etc) by abstracting away the underlying details.
+OpenShift Pipelines is a cloud-native, continuous integration and delivery (CI/CD) solution for building `pipelines` using link:https://tekton.dev[Tekton]. Tekton is a flexible, Kubernetes-native, open-source CI/CD framework that enables automating deployments across multiple platforms (e.g., Kubernetes, serverless, VMs, etc) by abstracting away the underlying details.
 
 OpenShift Pipelines features:
 
@@ -6,18 +6,18 @@ OpenShift Pipelines features:
 * Build images with Kubernetes tools such as `S2I`, `Buildah`, `Buildpacks`, `Kaniko`, etc
 * Deploy applications to multiple platforms such as Kubernetes, serverless and VMs
 * Easy to extend and integrate with existing tools
-* Scale pipelines on-demand
+* Scale `pipelines` on-demand
 * Portable across any Kubernetes platform
 * Designed for microservices and decentralized teams
 * Integrated with the OpenShift Developer Console
 
-This tutorial walks you through pipeline concepts and how to create and run a simple pipeline for building and deploying a containerized app on OpenShift.
+This tutorial walks you through `pipeline` concepts and how to create and run a simple `pipeline` for building and deploying a containerized app on OpenShift.
 
 In this tutorial you will:
 
 * Learn about Tekton concepts
-* Install OpenShift Pipelines
-* Deploy a Sample Application
-* Install Tasks
-* Create a Pipeline
-* Trigger a Pipeline
+* Install `tasks`
+* Create a `pipeline`
+* Add `pipelineresources`
+* Trigger a `pipelinerun`
+* Deploy a sample application on OpenShift from a `pipelinerun`


### PR DESCRIPTION
This pull request addresses issues related to converting the OpenShift pipelines tutorial from markdown to adoc, touches up language and grammar, and also adds `oc` commands for creating the `pipeline`, `tasks`, `pipelineresources`, and `pipelinerun`.

I will point out other considerations I included in this pr, including added **TODO**s.