### PR TITLE
Add Workshop Summary and Add Output of Verifying Permission for oc auth can-i use scc/privileged

### DIFF
--- a/workshop/content/exercises/deploy-sample-app.adoc
+++ b/workshop/content/exercises/deploy-sample-app.adoc
@@ -14,14 +14,14 @@ This workshop has created a ServiceAccount with the required permissions to run 
 oc get serviceaccount pipeline
 ----
 
-Now, let's verify that `pipeline` has the appropriate permissions to access the `privileged` Security Context Constrain (SCC):
+Now, let's verify that `pipeline` has the appropriate permissions to access the privileged Security Context Constrain (SCC):
 
 [source,bash,role=execute-1]
 ----
 oc auth can-i use scc/privileged
 ----
 
-= TODO: Add output to verify service account has appropriate permissions
+The command above should return `yes` if `pipeline` has access to SCC.
 
 Now that we have verified the `pipeline` account has appropriate permissions, let's focus on the application that will be deployed during this workshop.
 

--- a/workshop/content/workshop-summary.adoc
+++ b/workshop/content/workshop-summary.adoc
@@ -7,7 +7,7 @@ development tasks.
 
 We hope you have found this workshop helpful in learning about OpenShift Pipelines
 and would love any feedback you have on ways to make it better! Feel free to open
-issues in this workshop's [GitHub repository](https://github.com/openshift-labs/lab-openshift-pipelines-with-tekton)
+issues in this workshop's link:https://github.com/openshift-labs/lab-openshift-pipelines-with-tekton[GitHub repository]
 but also reach out to your workshop leaders to share any thoughts on how we can
 make this a better experience.
 

--- a/workshop/content/workshop-summary.adoc
+++ b/workshop/content/workshop-summary.adoc
@@ -1,1 +1,43 @@
-This is the last page of the workshop. Include in this page a summary of the workshop and any links to resources relevant to the workshop. This ensures anyone doing the workshop has material they can research later to learn more.
+In this workshop, you have worked with OpenShift Pipelines and learned about underlying
+Tekton concepts. OpenShift Pipelines provides CI/CD solutions for addressing the
+fundamentals of CI/CD (i.e., automating building, testing, and deploying application components),
+but also offers modern solutions around addressing scale, server maintenance, and
+making all parts of the CI/CD process highly reusable for any number of application
+development tasks.
+
+We hope you have found this workshop helpful in learning about OpenShift Pipelines
+and would love any feedback you have on ways to make it better! Feel free to open
+issues in this workshop's [GitHub repository](https://github.com/openshift-labs/lab-openshift-pipelines-with-tekton)
+but also reach out to your workshop leaders to share any thoughts on how we can
+make this a better experience.
+
+To learn more about OpenShift Pipelines and Tekton, the resources below can provide
+information on everything from getting started to more advanced concepts.
+
+OpenShift Pipelines Documentation:
+https://openshift.github.io/pipelines-docs/docs/index.html
+
+Tekton Pipelines GitHub:
+https://github.com/tektoncd/pipeline
+
+Tekton CLI GitHub:
+https://github.com/tektoncd/cli
+
+While the website is under construction at this time, please lookout in the
+future for information about Tekton to be available below:
+https://tekton.dev/
+
+Read more in the OpenShift blog announcement for OpenShift Pipelines:
+https://blog.openshift.com/cloud-native-ci-cd-with-openshift-pipelines/
+
+For examples of OpenShift Pipelines `tasks`, visit the `openshift/pipelines-catalog`
+GitHub:
+https://github.com/openshift/pipelines-catalog
+
+For examples of Tekton `pipelines` and `tasks`, visit the `tektoncd/catalog` GitHub
+repository:
+https://github.com/tektoncd/catalog
+
+To rerun parts of this tutorial on your own, check out the `openshift/pipelines-tutorial`
+GitHub repository:
+https://github.com/openshift/pipelines-tutorial

--- a/workshop/content/workshop-summary.adoc
+++ b/workshop/content/workshop-summary.adoc
@@ -23,7 +23,7 @@ https://github.com/tektoncd/pipeline
 Tekton CLI GitHub:
 https://github.com/tektoncd/cli
 
-While the website is under construction at this time, please lookout in the
+While the Tekton website is under construction at this time, please lookout in the
 future for information about Tekton to be available below:
 https://tekton.dev/
 


### PR DESCRIPTION
This pull request adds summary information for workshop attendees to find additional information about OpenShift Pipelines and Tekon. It also eliminates a `TODO` by verifying the correct output for `oc auth can-i use scc/privileged`.

The resources I have included are the OpenShift Pipelines documentation website, Tekton Pipelines/CLI github repos, Tekton website (still under construction, but people should be aware of it), the blog post announcing OpenShift Pipelines, GitHub repos for catalogs of `pipelines` and `tasks`, and the GitHub repo for the OpenShift Pipelines tutorial.