### PR TITLE
Fix tkn Commands for Tutorial and Remove git config from Build

### DIFF
--- a/.workshop/build
+++ b/.workshop/build
@@ -15,12 +15,6 @@ mv workshop /opt/app-root/workshop
 
 rm -f Dockerfile README.md LICENSE
 
-# If the workshop requires Git, it is necessary to set some defaults for
-# the name and email of the user for Git.
-
-git config --global user.email "you@example.com"
-git config --global user.name "Your Name"
-
 mv -f code/* . && rmdir code
 
 mkdir -p .bin && echo "export PATH=$HOME/.bin:$PATH" >> .bash_profile

--- a/workshop/content/exercises/create-pipeline.adoc
+++ b/workshop/content/exercises/create-pipeline.adoc
@@ -72,11 +72,16 @@ image:../images/console-import-yaml-1.png[OpenShift Console - Import Yaml Menu]
 
 image:../images/console-import-yaml-2.png[OpenShift Console - Import Yaml]
 
-You can check the list of `pipelines` you have created using the [Tekton CLI](https://github.com/tektoncd/cli/releases)(`tkn`):
+You can check the list of `pipelines` you have created using the Tekton CLI(`tkn`):
 
 [source,bash,role=execute-1]
 ----
-$ tkn pipeline ls
+tkn pipeline ls
+----
+
+The output should be similar to what is shown below:
+
+----
 NAME             AGE              LAST RUN   STARTED   DURATION   STATUS
 deploy-pipeline  25 seconds ago   ---        ---       ---        ---
 ----

--- a/workshop/content/exercises/trigger-pipeline.adoc
+++ b/workshop/content/exercises/trigger-pipeline.adoc
@@ -32,15 +32,23 @@ spec:
     value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/spring-petclinic
 ----
 
-Create the above pipeline resources via the OpenShift web console using the same steps used earlier for creating the `pipeline` or execute the following `oc` commands:
+Create the above pipeline resources via the OpenShift web console using the same steps used earlier for creating the `pipeline` or execute the `oc` commands below.
+
+Add the Git repository input for the `pipeline`:
 
 [source,bash,role=execute-1]
 ----
 oc create -f ./code/exercise/petclinic-git-pipeline-resource.yaml
+----
+
+Add the registry for the Spring PetClinic image to be pushed to as an output for the `pipeline`:
+
+[source,bash,role=execute-1]
+----
 oc create -f ./code/exercise/petclinic-image-pipeline-resource.yaml
 ----
 
-A `pipelinerun` is how you can trigger a `pipeline` and tie it to the Git and image resources that should be used for this specific invocation:
+A `pipelinerun` is how you can trigger a `pipeline` and tie it to the Git and image resources that are used for this specific invocation:
 
 [source,yaml]
 ----
@@ -72,22 +80,29 @@ oc create -f ./code/exercise/petclinic-deploy-pipelinerun.yaml
 
 The `pipeline` you created earlier is now instantiated and creating a number of pods to execute the `tasks` that are defined in the `pipeline`. After a few minutes, the `pipeline` should finish successfully.
 
-[source,bash,role=execute-1]
-----
-# tkn pr ls
-NAME                                 STARTED         DURATION    STATUS
-petclinic-deploy-pipelinerun-lkq7d   7 minutes ago   3 minutes   Succeeded
-----
-
-= TODO: Show how to view pipelinerun through web console
-
-Check the `pipelinerun` logs as it executes:
+To view the `pipelinerun` created, run the following `tkn` command:
 
 [source,bash,role=execute-1]
 ----
-$ tkn pr logs petclinic-deploy-pipelinerun-lkq7d -f
-...
+tkn pr ls
+----
 
+You can view the logs of `pipelinerun` as it executes either through the OpenShift web console or using the Tekton CLI. There are instructions for both options below.
+
+= TODO: Web Console Logs
+
+= Tekton CLI Logs
+
+You'll need to take the name of the `pipelinerun` from the output of `tkn pr ls` and add it to the command below. Next, copy and paste the command below into a terminal and run it with your `pipelinerun` name to see the logs.
+
+[source,bash]
+----
+tkn pr logs REPLACE_WITH_PIPELINERUN_NAME -f
+----
+
+Upon the successful completion of the `pipelinerun`, you will see the following output from the logs:
+
+----
 [s2i-java-8 : nop] Build successful
 
 [openshift-client : oc] deploymentconfig.apps.openshift.io/spring-petclinic rolled out
@@ -98,3 +113,5 @@ $ tkn pr logs petclinic-deploy-pipelinerun-lkq7d -f
 Looking back at the project, you should see that the PetClinic image is successfully built and deployed.
 
 images:images/petclinic-deployed-2.png[PetClinic Deployed]
+
+= TODO: Add how to view successfully deployed application via its route

--- a/workshop/content/exercises/trigger-pipeline.adoc
+++ b/workshop/content/exercises/trigger-pipeline.adoc
@@ -102,6 +102,7 @@ tkn pr logs REPLACE_WITH_PIPELINERUN_NAME -f
 
 Upon the successful completion of the `pipelinerun`, you will see the following output from the logs:
 
+[source,bash]
 ----
 [s2i-java-8 : nop] Build successful
 


### PR DESCRIPTION
This pull request fixes the `tkn` commands in the tutorial so that they are executable and also includes includes instructions for executing `tkn pr logs` manually since each `pipelinerun` name is generated uniquely. There may be a command in the future that allows the viewing of the most recent `pipelinerun` as opposed to a particular name for the `tkn pr logs` command, but this is not available for version of `tkn` used currently. This can be re-evaluated when it is implemented. 

This also restructures the `pipelinerun` section so that we can write out both `tkn` and web console instructions for viewing logs. 

Additionally, this removes the `git config` commands from `build` under `.workshop` since this tutorial does not require git access.