### PR TITLE
Fix oc create File Paths, Add tkn resource Command, and Add More Information about Tasks

### DIFF
--- a/.workshop/scripts/deploy-spawner.sh
+++ b/.workshop/scripts/deploy-spawner.sh
@@ -6,7 +6,7 @@ fail()
     exit 1
 }
 
-WORKSHOP_IMAGE="quay.io/openshiftlabs/lab-openshift-pipelines-with-tekton:1.0"
+WORKSHOP_IMAGE="quay.io/openshiftlabs/lab-openshift-pipelines-with-tekton:master"
 
 RESOURCE_BUDGET="x-large"
 LETS_ENCRYPT=${LETS_ENCRYPT:-false}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This workshop provides an introduction to OpenShift Pipelines with Tekton.
 
 The workshop uses the HomeRoom workshop environment in the learning portal configuration. You will need to be a cluster admin in order to deploy it.
 
-When the URL for the workshop environment is accessed, a workshop session will be created on demand. This will include a project for the session, into which the Kafka operator will have been pre-installed.
+When the URL for the workshop environment is accessed, a workshop session will be created on demand. This will include a project for the session, into which the OpenShift Pipelines operator will have been pre-installed.
 
 Deploying the Workshop
 ----------------------
@@ -24,7 +24,7 @@ From within the top level of the Git repository, now run:
 ./.workshop/scripts/deploy-spawner.sh
 ```
 
-The name of the deployment will be ``lab-openshift-pipelines-with-tekton``.
+The name of the deployment will be `lab-openshift-pipelines-with-tekton`.
 
 You can determine the hostname for the URL to access the workshop by running:
 
@@ -35,7 +35,7 @@ oc get route lab-openshift-pipelines-with-tekton
 Editing the Workshop
 --------------------
 
-The deployment created above will use a version of the workshop which has been pre-built into an image and which is hosted on ``quay.io``.
+The deployment created above will use a version of the workshop which has been pre-built into an image and which is hosted on `quay.io`.
 
 To make changes to the workshop content and test them, edit the files in the Git repository and then run:
 
@@ -47,9 +47,9 @@ This will replace the existing image used by the active deployment.
 
 If you are running an existing instance of the workshop, from your web browser select "Restart Workshop" from the menu top right of the workshop environment dashboard.
 
-When you are happy with your changes, push them back to the remote Git repository. This will automatically trigger a new build of the image hosted on ``quay.io``.
+When you are happy with your changes, push them back to the remote Git repository. This will automatically trigger a new build of the image hosted on `quay.io`.
 
-If you need to change the RBAC definitions, or what resources are created when a project is created, change the definitions in the ``templates`` directory. You can then re-run:
+If you need to change the RBAC definitions, or what resources are created when a project is created, change the definitions in the `templates` directory. You can then re-run:
 
 ```
 ./.workshop/scripts/deploy-spawner.sh

--- a/workshop/content/exercises/create-pipeline.adoc
+++ b/workshop/content/exercises/create-pipeline.adoc
@@ -61,7 +61,7 @@ The command below uses `oc` to take the `pipeline` definition from above from a 
 
 [source,bash,role=execute-1]
 ----
-oc create -f ./code/exercise/deploy-pipeline.yaml
+oc create -f exercise/deploy-pipeline.yaml
 ----
 
 = OpenShift Web Console

--- a/workshop/content/exercises/install-tasks.adoc
+++ b/workshop/content/exercises/install-tasks.adoc
@@ -23,16 +23,26 @@ spec:
     - install
 ----
 
-When a `task` starts running, it starts a pod and runs each step sequentially in a separate container on the same pod. This `task` happens to have a single step, but `tasks` can have multiple steps, and, since they run within the same pod, they have access to the same volumes in order to cache files, access configmaps, secrets, etc. `Tasks` can also receive inputs (e.g., a git repository) and outputs (e.g., an image in a registry) in order to interact with each other.
+When a `task` starts running, it starts a pod and runs each step sequentially in a separate container on the same pod. The `task` above happens to have a single step, but `tasks` can have multiple steps, and, since they run within the same pod, they have access to the same volumes in order to cache files, access configmaps, secrets, etc. `Tasks` can also receive inputs (e.g., a git repository) and outputs (e.g., an image in a registry) in order to interact with each other.
 
-As mentioned previously, only the requirement for a git repository is declared on the `task` and not a specific git repository to be used. That allows `tasks` to be reusable for multiple `pipelines` and purposes. You can find more examples of reusable `tasks` in the link:https://github.com/tektoncd/catalog[Tekton Catalog] and link:https://github.com/openshift/pipelines-catalog[OpenShift Catalog] repositories.
+For each step as part of a `task`, an image is declared that will be used to host the step as it executes. In the example above, the image specified is `maven:3.6.0-jdk-8-slim`. The `maven:3.6.0-jdk-8-slim` image allows the step to execute a `mvn install` command to add an artifact to a local repository.
 
-Install the `openshift-client` and `s2i-java` tasks from the catalog repository using `oc`, which you will need for creating a pipeline in the next section:
+As mentioned previously, only the requirement for a git repository is declared on the `task` above and not a specific git repository to be used. This allows `tasks` to be reusable for multiple `pipelines` and purposes. You can find more examples of reusable `tasks` in the link:https://github.com/tektoncd/catalog[Tekton Catalog] and link:https://github.com/openshift/pipelines-catalog[OpenShift Catalog] repositories.
+
+Install the `openshift-client` and `s2i-java-8` tasks from the catalog repositories using `oc`.
+
+Create the `s2i-java-8` `task` that will define and build a container image for a Java 8 application and push the image to an image registry:
 
 [source,bash,role=execute-1]
 ----
-oc create -f ./code/tektontasks/openshift-client-task.yaml
-oc create -f ./code/tektontasks/s2i-java-8-task.yaml
+oc create -f tektontasks/s2i-java-8-task.yaml
+----
+
+Create the `openshift-client` `task` that will deploy the image created by `s2i-java-8` as a container on OpenShift:
+
+[source,bash,role=execute-1]
+----
+oc create -f tektontasks/openshift-client-task.yaml
 ----
 
 **NOTE**: For convenience, the `tasks` have been copied from their original location in the link:https://github.com/tektoncd/catalog[Tekton Catalog] to the workshop.

--- a/workshop/content/exercises/trigger-pipeline.adoc
+++ b/workshop/content/exercises/trigger-pipeline.adoc
@@ -1,6 +1,6 @@
 Now that the `pipeline` is created, you can trigger it to execute the tasks specified in the `pipeline`. Triggering `pipelines` is an area that is under development and in the next release it will be possible to be done via the OpenShift web console and Tekton CLI. In this tutorial, you will trigger the pipeline through creating the Kubernetes objects (the hard way!) in order to learn the mechanics of triggering.
 
-First, you should create `pipelineresources` that contain the specifics of the Git repository and image registry to be used in the `pipeline` during execution. Expectedly, these are also reusable across multiple pipelines.
+First, you should create `pipelineresources` that contain the specifics of the Git repository and image registry to be used in the `pipeline` during execution. These are also reusable across multiple pipelines.
 
 The following `pipelineresource` defines the Git repository and reference for the PetClinic application:
 
@@ -32,21 +32,37 @@ spec:
     value: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/spring-petclinic
 ----
 
-Create the above pipeline resources via the OpenShift web console using the same steps used earlier for creating the `pipeline` or execute the `oc` commands below.
+Create the above `pipelineresources` via the OpenShift web console using the same steps used earlier for creating the `pipeline` or execute the `oc` commands below.
 
 Add the Git repository input for the `pipeline`:
 
 [source,bash,role=execute-1]
 ----
-oc create -f ./code/exercise/petclinic-git-pipeline-resource.yaml
+oc create -f exercise/petclinic-git-pipeline-resource.yaml
 ----
 
 Add the registry for the Spring PetClinic image to be pushed to as an output for the `pipeline`:
 
 [source,bash,role=execute-1]
 ----
-oc create -f ./code/exercise/petclinic-image-pipeline-resource.yaml
+oc create -f exercise/petclinic-image-pipeline-resource.yaml
 ----
+
+You can see the `pipelineresources` created using `tkn`:
+
+[source,bash,role=execute-1]
+----
+tkn resource ls
+----
+
+[source,bash]
+----
+NAME              TYPE    DETAILS
+petclinic-git     git     url: https://github.com/spring-projects/spring-petclinic
+petclinic-image   image   url: image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/spring-petclinic
+----
+
+= TODO: Trigger Pipeline via web console and CLI
 
 A `pipelinerun` is how you can trigger a `pipeline` and tie it to the Git and image resources that are used for this specific invocation:
 
@@ -75,7 +91,7 @@ Create the above `pipelinerun` via the OpenShift web console using the same step
 
 [source,bash,role=execute-1]
 ----
-oc create -f ./code/exercise/petclinic-deploy-pipelinerun.yaml
+oc create -f exercise/petclinic-deploy-pipelinerun.yaml
 ----
 
 The `pipeline` you created earlier is now instantiated and creating a number of pods to execute the `tasks` that are defined in the `pipeline`. After a few minutes, the `pipeline` should finish successfully.


### PR DESCRIPTION
This pull request adds the following:
* Fixes the file paths associated with the `oc create -f` commands used in the tutorial
* Adds `tkn resource ls` to verify that resources have been created (this is not currently available in 0.12, but an upcoming release is about to come out I am adding it in preparation)
* Adds more information about Tekton `tasks` to educate workshop participants
* Updates the `WORKSHOP_IMAGE` to use `master` tag so that a deployment pulls the latest content for the workshop