### PR TITLE
Change Service Account Name to Pipeline

### DIFF
--- a/.workshop/templates/configmap-extra-resources.yaml
+++ b/.workshop/templates/configmap-extra-resources.yaml
@@ -28,7 +28,7 @@ objects:
             "kind": "ServiceAccount",
             "apiVersion": "v1",
             "metadata": {
-              "name": "pipelines"
+              "name": "pipeline"
             }
           },
           {
@@ -40,7 +40,7 @@ objects:
             "subjects": [
               {
                 "kind": "ServiceAccount",
-                "name": "pipelines",
+                "name": "pipeline",
                 "namespace": "${project_namespace}"
               }
             ],


### PR DESCRIPTION
The tutorial is set up to work with a service account called `pipeline`, but the current service account being created in the resource definition is `pipelines`. This pull request changes the name to `pipeline`. 