### PR TITLE
Fix Broken Image Paths

### DIFF
--- a/workshop/content/exercises/create-pipeline.adoc
+++ b/workshop/content/exercises/create-pipeline.adoc
@@ -2,8 +2,6 @@ A `pipeline` defines a number of `tasks` that should be executed and how they in
 
 In this tutorial, you will create a `pipeline` that takes the source code of a Java Spring Boot application (i.e., Spring PetClinic) from GitHub and then builds and deploys it on OpenShift using link:https://docs.openshift.com/container-platform/4.1/builds/understanding-image-builds.html#build-strategy-s2i_understanding-image-builds[Source-to-Image (S2I)].
 
-image:../images/pipeline-diagram.svg[OpenShift OperatorHub]
-
 Below is a YAML file that represents the above pipeline:
 
 [source,yaml]

--- a/workshop/content/exercises/trigger-pipeline.adoc
+++ b/workshop/content/exercises/trigger-pipeline.adoc
@@ -129,6 +129,6 @@ Upon the successful completion of the `pipelinerun`, you will see the following 
 
 Looking back at the project, you should see that the PetClinic image is successfully built and deployed.
 
-images:images/petclinic-deployed-2.png[PetClinic Deployed]
+image:../images/petclinic-deployed-2.png[PetClinic Deployed]
 
 = TODO: Add how to view successfully deployed application via its route

--- a/workshop/content/verify-workshop-environment.adoc
+++ b/workshop/content/verify-workshop-environment.adoc
@@ -24,10 +24,11 @@ Or you can use the simplified version:
 ----
 oc auth can-i create Pipeline
 ----
-
-Did you type the command in yourself? If you did, click on the command here instead and you will find that it is executed for you. You can click on any command here in the workshop notes which has the image:images/glyphicon-play-circle.png[Play,16,16] icon shown to the right of it, and it will be copied to the interactive terminal and run for you.
-
 When run, if the response is `yes`, you have the appropriate access.
+
+Did you type the command in yourself? If you did, click on the icon next to the command instead, and you will find that it is executed for you. You can click on the icon next to any command here in the workshop notes. It will be copied to the interactive terminal and run for you. The icon is shown below:
+
+image:images/glyphicon-play-circle.png[Play,16,16]
 
 ---------------
 


### PR DESCRIPTION
This pull request fixes broken image paths used in the following sections:
* `create-pipeline.adoc`
* `verify-workshop-environment.adoc`
* `trigger-pipeline.adoc`