### PR TITLE
Remove namespace from petclinic.yaml

### DIFF
--- a/code/sampleapp/petclinic.yaml
+++ b/code/sampleapp/petclinic.yaml
@@ -81,7 +81,6 @@ spec:
       from:
         kind: ImageStreamTag
         name: spring-petclinic:latest
-        namespace: ${project_namespace}
     type: ImageChange
 ---
 apiVersion: v1


### PR DESCRIPTION
This pull request removes the `namespace` from `petclinic.yaml`'s `DeploymentConfig` definition since the project for each user is created dynamically as part of this workshop.