### PR TITLE
Adding Back CRDs for Workshop

### DIFF
--- a/.workshop/resources/101-subscription.yaml
+++ b/.workshop/resources/101-subscription.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    csc-owner-name: installed-custom-openshift-operators.openshift-marketplace
+    csc-owner-namespace: openshift-marketplace
+  name: openshift-pipelines-operator
+  namespace: openshift-operators
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: openshift-pipelines-operator
+  source: installed-custom-openshift-operators
+  sourceNamespace: openshift-operators
+  startingCSV: openshift-pipelines-operator.v0.5.0

--- a/.workshop/resources/200-pipelines-privileged-clusterrole.yaml
+++ b/.workshop/resources/200-pipelines-privileged-clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    openshift.io/description: "Role-Based Access to SCCs for Tekton Pipelines privileged tasks"
+  name: pipelines-privileged-user
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - privileged

--- a/.workshop/resources/catalogsource.yaml
+++ b/.workshop/resources/catalogsource.yaml
@@ -1,0 +1,16 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  labels:
+    csc-owner-name: installed-custom-openshift-operators
+    csc-owner-namespace: openshift-marketplace
+  name: installed-custom-openshift-operators
+  namespace: openshift-operators
+spec:
+  address: installed-custom-openshift-operators.openshift-marketplace:50051
+  displayName: Custom Operators
+  icon:
+    base64data: ""
+    mediatype: ""
+  publisher: Custom
+  sourceType: grpc

--- a/.workshop/scripts/deploy-spawner.sh
+++ b/.workshop/scripts/deploy-spawner.sh
@@ -59,7 +59,13 @@ echo
 echo "### Install global operator definitions if not already available."
 echo
 
-oc apply -f .workshop/resources/ --recursive
+if [ -d ".workshop/resources/" ]; then
+    oc apply -f .workshop/resources/ --recursive
+else
+    echo
+    echo "### No /resources/ directory found. Continuing deployment."
+    echo
+fi
 
 if [ "$?" != "0" ]; then
     fail "Error: Failed to create global operator definitions."


### PR DESCRIPTION
This pull request adds back CRDs needed to run the tutorial that were removed in #8. It also adds some validation if the `resources` directory exists.