### PR TITLE
Increase Max Session Age to Two Hours

### DIFF
--- a/.workshop/settings.sh
+++ b/.workshop/settings.sh
@@ -2,5 +2,5 @@ WORKSHOP_NAME=lab-tekton-pipelines
 WORKSHOP_IMAGE=quay.io/openshiftlabs/lab-openshift-pipelines-with-tekton:master
 CONSOLE_IMAGE=quay.io/openshift/origin-console:4.2
 RESOURCE_BUDGET=custom
-MAX_SESSION_AGE=3600
+MAX_SESSION_AGE=7200
 IDLE_TIMEOUT=300


### PR DESCRIPTION
This pull request increases `MAX_SESSION_AGE` from 3600 to 7200 so that the workshop session will be alive for at least two hours. While the workshop itself will not take two hours at this time, more content will be added in the coming weeks that will require a longer session. 